### PR TITLE
Add Daemon Feedback to Commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,7 +59,7 @@ checksum = "5988cb1d626264ac94100be357308f29ff7cbdd3b36bda27f450a4ee3f713426"
 
 [[package]]
 name = "brightness_control"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "bincode",
  "daemonize",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "brightness_control"
-version = "1.4.0"
+version = "1.4.1"
 authors = ["Sridaran Thoniyil <sri7thon@gmail.com>"]
 edition = "2018"
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ All brightness_control options have shorthands. For most of them, the first lett
 
 When using shorthands, the separating space between an option and its value may be omitted. This is shown in the first example, and can be applied to any option that takes a value
 
+Since version `1.4.1`, client commands that interact with the daemon will return feedback. To suppress this output (when using keybindings, for example), pass the `--quiet` or `-q` flag with the command. This flag allows the client to terminate and shutdown the socket without having to wait for the daemon to respond.
+
 *To Reduce the Brightness by 10%*
 ```
 $ brightness_control --decrement 10

--- a/src/client.rs
+++ b/src/client.rs
@@ -100,7 +100,7 @@ pub fn handle_input(matches: Matches) -> Result<()> {
 
     socket.write_all(&binary_encoded_input)?;
 
-    if program_input.returns_feedback() {
+    if !matches.opt_present("quiet") {
         // TODO figure out if a read timeout is necessary
         let buffered_reader = BufReader::with_capacity(512, &mut socket);
         for line in buffered_reader.lines() {

--- a/src/client.rs
+++ b/src/client.rs
@@ -7,8 +7,6 @@ use std::os::unix::net::UnixStream;
 
 use std::io::{BufRead, BufReader};
 
-use std::time::Duration;
-
 use crate::daemon::*;
 
 fn check_brightness(matches: &Matches) -> Result<Option<BrightnessChange>> {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -343,19 +343,6 @@ impl Daemon {
         Ok(())
     }
 
-    // pass in blank input to process_input to refresh
-    fn refresh_configuration(&mut self) -> Result<()> {
-        let blank_input = ProgramInput {
-            brightness: None,
-            toggle_nightlight: false,
-            configure_display: false,
-            reload_configuration: false,
-            save_configuration: false
-        };
-
-        self.process_input(blank_input, None)
-    }
-
     // boolean signals whether to early return or not in process_input
     fn refresh_brightness(&mut self) -> Result<bool> {
         let mut _call_handle = self.create_xrandr_command().spawn()?;
@@ -406,6 +393,13 @@ impl Daemon {
             }
         }
 
+        Ok(())
+    }
+
+    fn refresh_configuration(&mut self) -> Result<()> {
+        // don't need the early return flag here
+        let _ = self.refresh_brightness()?;
+        self.refresh_if_redshift()?;
         Ok(())
     }
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -354,7 +354,6 @@ impl Daemon {
             // if the call fails, then the configuration is no longer valid
             // reconfigures the display and then tries again
             if !exit_status.success() {
-                println!("Reconfiguring!");
                 // force reconfigure
                 self.reconfigure_displays()?;
                 self.create_xrandr_command().spawn()?;

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -408,7 +408,7 @@ impl Daemon {
         // struct elements
         let brightness = program_input.brightness;
         let toggle_nightlight = program_input.toggle_nightlight;
-        let configure_display = program_input.configure_display;
+        let mut configure_display = program_input.configure_display;
         let reload_configuration = program_input.reload_configuration;
         let save_configuration = program_input.save_configuration;
 
@@ -426,7 +426,12 @@ impl Daemon {
                     }
                 };
 
-                self.refresh_brightness()?;
+                // this returns true if refresh_brightness reconfigured the display automatically
+                // dont want to reconfigure AGAIN
+                let skip_configure_display = self.refresh_brightness()?;
+                if skip_configure_display {
+                    configure_display = false;
+                }
             },
             None => ()
         };

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1,6 +1,5 @@
 use daemonize::Daemonize;
 use bincode::{Options, DefaultOptions};
-use toml::Value;
 use directories::ProjectDirs;
 
 use serde::{Serialize, Deserialize};

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -319,7 +319,7 @@ impl Daemon {
                     match program_input {
                         Ok(program_input) => {
                             println!("Deserialized ProgramInput: {:?}", program_input);
-                            self.process_input(program_input, Some(&mut stream))?;
+                            self.process_input(program_input, &mut stream)?;
                         },
                         Err(err) => {
                             eprintln!("Error deserializing: {}", err);
@@ -402,7 +402,7 @@ impl Daemon {
         Ok(())
     }
 
-    fn process_input(&mut self, program_input: ProgramInput, socket: Option<&mut UnixStream>) -> Result<()> {
+    fn process_input(&mut self, program_input: ProgramInput, socket: &mut UnixStream) -> Result<()> {
         // avoided using destructuring because destructuring relies entirely on the order of the
         // struct elements
         let brightness = program_input.brightness;

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -383,10 +383,10 @@ impl Daemon {
 
     fn refresh_redshift(&mut self) -> Result<()> {
         if self.mode {
-            self.enable_redshift();
+            self.enable_redshift()?;
         }
         else {
-            self.clear_redshift();
+            self.clear_redshift()?;
         }
 
         Ok(())

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -319,7 +319,7 @@ impl Daemon {
                     match program_input {
                         Ok(program_input) => {
                             println!("Deserialized ProgramInput: {:?}", program_input);
-                            self.process_input(program_input, &mut stream)?;
+                            self.process_input(program_input, &mut stream);
                         },
                         Err(err) => {
                             eprintln!("Error deserializing: {}", err);
@@ -402,7 +402,7 @@ impl Daemon {
         Ok(())
     }
 
-    fn process_input(&mut self, program_input: ProgramInput, socket: &mut UnixStream) -> Result<()> {
+    fn process_input(&mut self, program_input: ProgramInput, socket: &mut UnixStream) {
         // avoided using destructuring because destructuring relies entirely on the order of the
         // struct elements
         let brightness = program_input.brightness;
@@ -500,8 +500,6 @@ impl Daemon {
                 write_message("Successfully saved configuration!");
             }
         }
-
-        Ok(())
     }
 
     fn reconfigure_displays(&mut self) -> Result<()> {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -343,7 +343,7 @@ impl Daemon {
         Ok(())
     }
 
-    // boolean signals whether to early return or not in process_input
+    // boolean signals whether to skip display reconfiguration in process_input
     fn refresh_brightness(&mut self) -> Result<bool> {
         let mut _call_handle = self.create_xrandr_command().spawn()?;
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -448,6 +448,8 @@ impl Daemon {
                 // dont want to reconfigure AGAIN
                 match self.refresh_brightness() {
                     Ok(skip_configure_display) => {
+                        write_message(&format!("Set brightness to {}%", self.brightness));
+
                         if skip_configure_display {
                             configure_display = false;
                             write_message("Automatically reconfigured displays!");

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -411,7 +411,7 @@ impl Daemon {
         let reload_configuration = program_input.reload_configuration;
         let save_configuration = program_input.save_configuration;
 
-        let write_message = move |message: &str| {
+        let mut write_message = move |message: &str| {
             if let Err(e) = socket.write_all(message.as_bytes()) {
                 eprintln!("Failed to write \"{}\" to socket: {}", message, e);
             }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -499,7 +499,7 @@ impl Daemon {
                     }
                 },
                 Err(e) => {
-                    write_message("Failed to open configuration file for reloading!");
+                    write_message(&format!("Failed to open configuration file for reloading: {}", e));
                 }
             }
         }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -421,7 +421,7 @@ impl Daemon {
             self.mode = !self.mode;
 
             if let Err(e) = self.refresh_if_redshift() {
-                write_message(format!("Failed to refresh redshift: {}", e));
+                write_message(&format!("Failed to refresh redshift: {}", e));
             }
             else {
                 // could have used format! to make this a one-liner, but this allows the strings to be
@@ -454,7 +454,7 @@ impl Daemon {
                         }
                     },
                     Err(e) => {
-                        write_message(format!("Failed to refresh brightness: {}", e));
+                        write_message(&format!("Failed to refresh brightness: {}", e));
                     }
                 };
             },
@@ -463,7 +463,7 @@ impl Daemon {
 
         if configure_display {
             if let Err(e) = self.reconfigure_displays() {
-                write_message(format!("Failed to reconfigure displays: {}", e));
+                write_message(&format!("Failed to reconfigure displays: {}", e));
             }
             else {
                 write_message("Successfully reconfigured displays!");
@@ -482,7 +482,7 @@ impl Daemon {
                             write_message("Successfully reloaded configuration!");
                         }
                         Err(error) => {
-                            write_message(format!("Failed to parse configuration file: {}", error));
+                            write_message(&format!("Failed to parse configuration file: {}", error));
                         }
                     }
                 },
@@ -494,7 +494,7 @@ impl Daemon {
 
         if save_configuration {
             if let Err(e) = self.save_configuration() {
-                write_message(format!("Failed to save configuration: {}", e));
+                write_message(&format!("Failed to save configuration: {}", e));
             }
             else {
                 write_message("Successfully saved configuration!");

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -430,6 +430,7 @@ impl Daemon {
                 else {
                     if let Err(e) = self.refresh_brightness() {
                         write_message(&format!("Failed to refresh xrandr: {}", e));
+                        return;
                     }
                 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,7 @@ fn get_cli_interface() -> Options {
         .optflag("c", "configure-display", "Uses the current display configuration for future calls to BrightnessControl")
         .optflag("t", "toggle-nightlight", "Toggles the nightlight mode on/off")
         .optflag("r", "reload-configuration", "Tells the daemon to re-read the configuration file and apply new changes")
+        .optflag("q", "quiet", "Do not wait for the Daemon's output before terminating")
         .optopt("s", "set", "Sets the current brightness to some percentage [0..100]", "PERCENTAGE")
         .optopt("i", "increment", "Increments the current brightness by some (integer) percentage between -100 and +100", "PERCENTAGE")
         .optopt("d", "decrement", "Decrements the current brightness by some (integer) percentage between -100 and +100", "PERCENTAGE");


### PR DESCRIPTION
This PR makes the Daemon respond to the client with feedback for all relevant commands.

This output can be suppressed client-side by using the new `--quiet` flag.

Currently, the `ProgramInput` struct does not include the `--quiet` flag, so the Daemon will write to the socket regardless of whether or not the client is listening. This may change in the future.

