### PR TITLE
Remove all unsafe usage in code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,7 +90,7 @@ checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
 
 [[package]]
 name = "brightness_control"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "bincode",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "brightness_control"
-version = "2.2.0"
+version = "2.3.0"
 authors = ["Sridaran Thoniyil <sri7thon@gmail.com>"]
 edition = "2018"
 

--- a/README.md
+++ b/README.md
@@ -1,264 +1,177 @@
 # BrightnessControl
 
-## Disclaimer: Linux + Xorg Only
+A command-line tool for adjusting screen brightness on Linux systems using Xorg. Unlike traditional backlight controls, BrightnessControl uses `xrandr` to modify display brightness at the software level, giving you fine-grained control over your monitors.
 
-[![Build Status](https://travis-ci.org/srithon/BrightnessControl.svg?branch=master)](https://travis-ci.org/srithon/BrightnessControl)
+## Features
 
-`BrightnessControl` is a wrapper around `xrandr` that allows for easy adjustments of brightness.
+- **Per-monitor brightness control** - Set different brightness levels for each connected display
+- **Smooth brightness transitions** - Gradual fading between brightness levels
+- **Blue light filter** - Built-in night light functionality using `xrandr` or `redshift`
+- **Multi-monitor support** - Control all monitors simultaneously or target specific displays
+- **Daemon architecture** - Fast, responsive brightness adjustments with persistent settings
 
-This brightness is separate from the backlight.
+## Requirements
 
-It also allows for an emulation of a blue light filter / night light, which can be toggled on/off. This emulation is part of `xrandr` itself.
-
-To use `redshift` instead of `xrandr` for the blue light filter, set `use_redshift` to `true` in the configuration file. More details on this will be in the `Configuration` section
-
-Since version `1.4.5`, `BrightnessControl` can smoothly fade between brightness levels. More information on brightness fading can be found in the configuration template.
-
-Since version `1.6.0`, `BrightnessControl` processes input asynchronously, **and multiple monitors function as expected**
-
-Since version `2.0.0-alpha0`, `BrightnessControl` supports different brightness levels per monitor
-
-## Technical Details
-
-Since version `1.3.0`, `BrightnessControl` uses a daemon to interface with `xrandr`, and client instances to interface with the daemon.
-
-When the daemon is started, it loads the following values from disk
-* stored in `~/.cache/brightnesscontrol/persistent_state.toml`
-  * brightness: map of `<adapter name> = [0..100]`; percentage of full brightness
-  * nightlight: `true` or `false`; `false` means nightlight is off, `true` means it is on
-
-If the values cannot be parsed correctly, the daemon will instead use the default values.
-
-After starting, the daemon stores all of these values in memory, and does not touch the files again until it receives a `SIGTERM` signal.
-
-Upon receiving this signal, the daemon writes all of the new values to the filesystem and terminates.
-
-Manually modifying these files while the daemon is running will have no effect.
-
-### Runtime
-
-If the daemon's call to `xrandr` *fails* as a result of invalid/outdated data in its in-memory `displays` field, the program will automatically remove the corresponding display from the list **IF** `auto_remove_displays` is set to `true` in the configuration file.
-
-When this is not enabled, each individual client message takes less time to process because the daemon does not have to wait for each `xrandr` call to terminate before moving onto the next one
-
-If your display configuration is mostly static, consider disabling this option.
-
-For users that often disconnect and reconnect monitors, two external options are the [autorandr](https://github.com/phillipberndt/autorandr) and [srandrd](https://github.com/jceb/srandrd) programs.
-
-Both programs can be used to automatically call `brightness_control monitors --reconfigure-displays` whenever the monitor setup changes
-
-This is a good alternative to `auto_remove_displays`, which also has the advantage of working when a _new_ monitor is connected
-
-Instructions on how to configure these programs to work with this application will be added in the future.
-
-Instructions on how to enable/disable `auto_remove_displays` are in the Installation section
-
-## Build Dependencies
-**NOTE**: since `v1.4.1`, you can download pre-compiled binaries from [GitHub releases](https://github.com/srithon/BrightnessControl/releases). These binaries are packaged by Travis CI. If you do not want to download `Rust` (admittedly a pretty big dependency), you should consider downloading and using these binaries.
-
-1) `cargo`
-
-The easiest way to install `cargo` is through `rustup`: the Rust toolchain installer.
-
-The following command is taken directly from the [cargo installation page](https://doc.rust-lang.org/cargo/getting-started/installation.html).
-
-It downloads the `rustup` installation script and pipes it into `sh`, which executes it directly.
-
-`$ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh`
-
-To read the script before it executes, you can redirect the output into a file by replacing `| sh` with `> filename.sh`. After reading `filename.sh`, you can execute it from there.
-
-**Alternatively**, you can download the `rustup` package from your distro's (most likely) official repositories.
-
-**Ubuntu**: `sudo apt install rustup`
-
-**Arch Linux**: `sudo pacman -S rustup`
-
-_With rustup installed_...
-```
-$ rustup toolchain install stable
-$ rustup default stable
-```
-
-This should install `cargo` for you.
-
-## Runtime Dependencies
-1) `xrandr`
-
-`xrandr` may already be installed on your computer. Type `xrandr` into your shell to check.
-
-**Ubuntu**: `sudo apt install x11-xserver-utils `
-
-**Arch Linux**: `sudo pacman -S xorg-xrandr`
-
-2) `redshift` (optional)
-
-**Ubuntu**: `sudo apt install redshift`
-
-**Arch Linux**: `sudo pacman -S redshift`
-
-Source: [https://github.com/jonls/redshift](https://github.com/jonls/redshift)
+- Linux with Xorg (Wayland not supported)
+- `xrandr` (usually pre-installed)
+- `redshift` (optional, for enhanced blue light filtering)
 
 ## Installation
-*From the project root*
 
+### Option 1: Pre-compiled Binaries (Recommended)
+
+Download the latest binary from [GitHub Releases](https://github.com/srithon/BrightnessControl/releases) and place it in your PATH.
+
+### Option 2: Build from Source
+
+1. Install Rust:
+```bash
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 ```
+
+2. Install runtime dependencies:
+```bash
+# Ubuntu/Debian
+sudo apt install x11-xserver-utils redshift
+
+# Arch Linux
+sudo pacman -S xorg-xrandr redshift
+```
+
+3. Build and install:
+```bash
 cargo install --path . --root ~/.local/
 ```
 
-***
+Make sure `~/.local/bin` is in your PATH.
 
-`cargo` will append `bin/` to the end of the path that you pass in for `--root`, so the above command will install the executable into `~/.local/bin/`
+## Quick Start
 
-### Configuring Redshift
-*Change redshift's adjustment mode*
-```
-sed -i 's/adjustment-method=randr/adjustment-method=vidmode/' ~/.config/redshift.conf
-```
-
-## Usage
-*All examples assume that the name of the executable is `brightness_control` and that the executable can be found in one of the directories in the `PATH` environmental variable*
-
-All brightness_control options have shorthands. For most of them, the first letter of the option's name acts as the shorthand.
-
-When using shorthands, the separating space between an option and its value may be omitted. This is shown in the first example, and can be applied to any option that takes a value
-
-*To Reduce the Brightness by 10%*
-```
-$ brightness_control brightness --decrement 10
-```
-or
-```
-$ brightness_control b -d10
+1. **Start the daemon:**
+```bash
+brightness_control daemon --start
 ```
 
-*To Increase the Brightness by 10%*
-```
-$ brightness_control b --increment 10
+2. **Adjust brightness:**
+```bash
+# Increase brightness by 10%
+brightness_control brightness --increment 10
+
+# Set brightness to 50%
+brightness_control brightness --set 50
+
+# Decrease brightness by 5%
+brightness_control brightness --decrement 5
 ```
 
-*To Increase the Brightness by 10% for the Active Monitor*
-```
-$ brightness_control --active b --increment 10
-```
-
-*To Increase the Brightness by 10% for the Monitor "eDP-1"*
-```
-$ brightness_control -m eDP-1 b --increment 10
+3. **Toggle night light:**
+```bash
+brightness_control nightlight --toggle
 ```
 
-*To Set the Brightness to 80%*
-```
-$ brightness_control b --set 80
+## Usage Examples
+
+### Basic Brightness Control
+
+```bash
+# Using full commands
+brightness_control brightness --increment 10
+brightness_control brightness --set 80
+
+# Using shortcuts (same functionality)
+brightness_control b -i10
+brightness_control b -s80
 ```
 
-*To Set the Brightness to 80% for All Enabled Monitors*
-```
-$ brightness_control --enabled b --set 80
+### Multi-Monitor Control
+
+```bash
+# Control all connected monitors
+brightness_control --enabled brightness --set 70
+
+# Control specific monitor
+brightness_control --monitor eDP-1 brightness --increment 15
+
+# Control the "active" monitor (BrightnessControl's concept)
+brightness_control --active brightness --decrement 5
 ```
 
-_To Set the Brightness to 50% Without Fading_
-```
-$ brightness_control b -ns80
+### Advanced Features
+
+```bash
+# Set brightness without smooth fading
+brightness_control b --no-fade --set 60
+
+# Interrupt current fade and change brightness
+brightness_control b --terminate-fade --increment 10
+
+# Get current brightness levels
+brightness_control get --brightness
+
+# List connected displays
+brightness_control get --displays
 ```
 
-_To Terminate the Current Brightness Fade_
-```
-$ brightness_control b -t
-```
+### Monitor Management
 
-_To Terminate the Current Brightness Fade for Monitor "HDMI-1"_
-```
-$ brightness_control -m HDMI-1 b -t
-```
+```bash
+# Refresh display configuration (after connecting/disconnecting monitors)
+brightness_control monitors --reconfigure-displays
 
-_To Terminate/Interrupt the Current Brightness Fade and Decrement the Brightness by 10%_
-```
-$ brightness_control b -td10
-```
-
-*To Toggle Night Light*
-```
-$ brightness_control nightlight --toggle
-```
-
-*To Reconfigure the Cached Display Settings*
-
-This is necessary when a new display adapter is connected
-```
-$ brightness_control m -r
-```
-
-*To Start the Daemon*
-```
-$ brightness_control daemon --start
-```
-
-*To View the Help Menu*
-```
-$ brightness_control --help
-```
-
-_To Print Out the Current Configuration Template_
-```
-$ brightness_control config --print-config-template
-```
-
-_To Print Out the Current Brightness for All Enabled Monitors_
-```
-$ brightness_control --enabled get -b
-```
-
-_To Print Out the Current Brightness for Monitor "eDP-1"_
-```
-$ brightness_control -m eDP-1 get -b
-```
-
-_To Print Out the Currently Loaded Configuration_
-```
-$ brightness_control g --configuration
-```
-
-*To Reload the Daemon Configuration*
-```
-$ brightness_control c --reload
+# Set active monitor for --active flag
+brightness_control monitors --set-active HDMI-1
 ```
 
 ## Configuration
-`BrightnessControl`'s reads its runtime configuration from `~/.config/brightnesscontrol/config.toml`
-If the file does not exist when the daemon is started, it automatically creates the file and writes the default configuration.
 
-The default configuration template is stored in `~/.local/share/brightnesscontrol/config_template.toml`
+BrightnessControl stores its configuration in `~/.config/brightnesscontrol/config.toml`. The daemon creates this file with default settings on first run.
 
-All available options are documented in the template
+To see all available options:
+```bash
+brightness_control config --print-config-template
+```
 
-### Technical Details
-The daemon writes the template to disk when it is first started. To do this manually, copy the output of `brightness_control c --print-default` to the file.
+To reload configuration without restarting:
+```bash
+brightness_control config --reload
+```
 
-Whenever the daemon is started, it checks to see if the configuration template is out of date. If it is, then it overwrites it with the current template.
+### Key Configuration Options
 
-When the daemon overwrites the template, it will indicate this through stdout. `BrightnessControl` will never overwrite your personal configuration, so whenever new options are added to the template, they have to be copied over manually.
+- **Brightness fading**: Control smooth transitions between brightness levels
+- **Blue light filter**: Choose between `xrandr` (default) or `redshift`
+- **Auto-remove displays**: Automatically handle disconnected monitors
+- **Default monitor behavior**: Set how commands apply to monitors by default
 
-You can reload the configuration without restarting the daemon by running `brightness_control config --reload` as shown above.
+### Configuring Redshift
 
-If the file cannot be parsed, the client will print out the error.
+To allow `brightness_control` to use `redshift` as a blue light filter while still using `xrandr` for brightness control, you must change redshift's adjustment mode away from `randr` to `vidmode`.
+```bash
+sed -i 's/adjustment-method=randr/adjustment-method=vidmode/' ~/.config/redshift.conf
+```
 
-## Keybinding
-All of these commands can be bound to keybindings for ease-of-use.
+## Keybinding Setup
 
-In the future, this functionality may be integrated directly into the application, but for now this can be done with [xbindkeys](https://wiki.archlinux.org/index.php/Xbindkeys) or other similar utilities.
+For convenient daily use, bind these commands to keyboard shortcuts using your desktop environment's settings or tools like `xbindkeys`:
 
-An example schema is below
+```bash
+# Example keybindings
+Alt+PageUp     → brightness_control b -i10    # Increase brightness
+Alt+PageDown   → brightness_control b -d10    # Decrease brightness
+Alt+End        → brightness_control n -t      # Toggle night light
+Alt+Home       → brightness_control m -r      # Refresh displays
+```
 
-Alt+PgUp        -> `brightness_control b -i10`
+## Troubleshooting
 
-Alt+PgDown      -> `brightness_control b -d10`
+**Daemon won't start**: Check if another instance is running with `killall brightness_control`
 
-Alt+Ctrl+PgUp   -> `brightness_control b -i2`
+**No brightness change**: Ensure `xrandr` works directly and your display supports software brightness control
 
-Alt+Ctrl+PgDown -> `brightness_control b -d2`
+**Monitor not detected**: Run `brightness_control monitors --reconfigure-displays` after connecting new displays
 
-Alt+End         -> `brightness_control n -t`
+## How It Works
 
-Alt+Home        -> `brightness_control m -r`
+BrightnessControl uses a client-daemon architecture. The daemon interfaces with `xrandr` to modify display gamma/brightness values, while client commands communicate with the daemon for fast response times. Settings are automatically saved and restored between sessions.
 
+This approach provides software-level brightness control that works independently of hardware backlight controls, making it especially useful for external monitors or systems where hardware brightness adjustment isn't available.

--- a/src/daemon/core/core.rs
+++ b/src/daemon/core/core.rs
@@ -32,7 +32,7 @@ use crate::{
         config::{persistent::*, runtime::*},
         core::display::*,
         fs::*,
-        util::{atomic::{Atomic, AtomicNumber}, io::*},
+        util::{atomic::Atomic, io::*},
     },
     shared::*,
 };
@@ -1032,7 +1032,8 @@ impl Daemon {
 
                         println!("Starting {i} brightness: {starting_brightness}");
 
-                        let ending_brightness = brightness.fetch_add(split_monitor_info.brightness_change_info.brightness_step, Ordering::Relaxed);
+                        let ending_brightness = starting_brightness + split_monitor_info.brightness_change_info.brightness_step;
+                        brightness.store(ending_brightness, Ordering::Relaxed);
 
                         println!("{i} brightness: {ending_brightness}");
                     }

--- a/src/daemon/util/atomic.rs
+++ b/src/daemon/util/atomic.rs
@@ -7,10 +7,6 @@ pub trait Atomic {
     fn store(&self, val: Self::Underlying, ordering: Ordering);
 }
 
-pub trait AtomicNumber: Atomic {
-    fn fetch_add(&self, val: Self::Underlying, ordering: Ordering) -> Self::Underlying;
-}
-
 impl Atomic for AtomicBool {
     type Underlying = bool;
     
@@ -46,11 +42,5 @@ impl Atomic for AtomicF64 {
     
     fn store(&self, val: f64, ordering: Ordering) {
         self.inner.store(val.to_bits(), ordering);
-    }
-}
-
-impl AtomicNumber for AtomicF64 {
-    fn fetch_add(&self, val: f64, ordering: Ordering) -> f64 {
-        f64::from_bits(self.inner.fetch_add(val.to_bits(), ordering))
     }
 }

--- a/src/daemon/util/atomic.rs
+++ b/src/daemon/util/atomic.rs
@@ -1,0 +1,56 @@
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+
+pub trait Atomic {
+    type Underlying;
+    fn new(initial: Self::Underlying) -> Self;
+    fn load(&self, ordering: Ordering) -> Self::Underlying;
+    fn store(&self, val: Self::Underlying, ordering: Ordering);
+}
+
+pub trait AtomicNumber: Atomic {
+    fn fetch_add(&self, val: Self::Underlying, ordering: Ordering) -> Self::Underlying;
+}
+
+impl Atomic for AtomicBool {
+    type Underlying = bool;
+    
+    fn new(initial: bool) -> Self {
+        AtomicBool::new(initial)
+    }
+    
+    fn load(&self, ordering: Ordering) -> bool {
+        self.load(ordering)
+    }
+    
+    fn store(&self, val: bool, ordering: Ordering) {
+        self.store(val, ordering);
+    }
+}
+
+pub struct AtomicF64 {
+    inner: AtomicU64,
+}
+
+impl Atomic for AtomicF64 {
+    type Underlying = f64;
+    
+    fn new(initial: f64) -> Self {
+        Self {
+            inner: AtomicU64::new(initial.to_bits()),
+        }
+    }
+    
+    fn load(&self, ordering: Ordering) -> f64 {
+        f64::from_bits(self.inner.load(ordering))
+    }
+    
+    fn store(&self, val: f64, ordering: Ordering) {
+        self.inner.store(val.to_bits(), ordering);
+    }
+}
+
+impl AtomicNumber for AtomicF64 {
+    fn fetch_add(&self, val: f64, ordering: Ordering) -> f64 {
+        f64::from_bits(self.inner.fetch_add(val.to_bits(), ordering))
+    }
+}

--- a/src/daemon/util/lock.rs
+++ b/src/daemon/util/lock.rs
@@ -1,66 +1,60 @@
+use std::sync::atomic::Ordering;
+
 use tokio::sync::{Mutex, MutexGuard};
 
-use std::cell::Cell;
+use super::atomic::Atomic;
 
-pub struct MutexGuardRefWrapper<'a, T: Copy, K> {
-    internal: &'a mut T,
+pub struct MutexGuardRefWrapper<'a, T: Atomic, K> {
+    internal: &'a T,
     pub mutex_guard: MutexGuard<'a, K>,
 }
 
 impl<'a, T, K> MutexGuardRefWrapper<'a, T, K>
 where
-    T: Copy,
+    T: Atomic,
 {
-    pub fn set(&mut self, new_value: T) {
-        *self.internal = new_value;
+    pub fn set(&mut self, new_value: T::Underlying) {
+        self.internal.store(new_value, Ordering::Relaxed);
     }
 
-    pub fn get(&self) -> T {
-        *self.internal
+    pub fn get(&self) -> T::Underlying {
+        self.internal.load(Ordering::Relaxed)
     }
 
-    pub fn get_mut(&mut self) -> &mut T {
-        self.internal
-    }
-
-    pub fn split<'b>(&'b mut self) -> (&'b mut T, &'b mut MutexGuard<'a, K>) {
-        (&mut self.internal, &mut self.mutex_guard)
+    pub fn split(&mut self) -> (&T, &mut MutexGuard<'a, K>) {
+        (&self.internal, &mut self.mutex_guard)
     }
 }
 
 // a version of RWLock that does not block readers from reading while a writer writes
 // by providing them with a copy of the internal value
 // this is meant to be used with primitives which have cheap Copy implementations
-pub struct NonReadBlockingRWLock<T: Copy, K> {
-    internal: Cell<T>,
+pub struct NonReadBlockingRWLock<T: Atomic, K> {
+    internal: T,
     write_mutex: Mutex<K>,
 }
 
-unsafe impl<T, K> Send for NonReadBlockingRWLock<T, K> where T: Copy {}
-
-unsafe impl<T, K> Sync for NonReadBlockingRWLock<T, K> where T: Copy {}
-
 impl<T, K> NonReadBlockingRWLock<T, K>
 where
-    T: Copy,
+    T: Atomic,
 {
-    pub fn new(initial_value: T, mutex_value: K) -> NonReadBlockingRWLock<T, K> {
+    pub fn new(initial_value: T::Underlying, mutex_value: K) -> NonReadBlockingRWLock<T, K> {
         NonReadBlockingRWLock {
-            internal: Cell::new(initial_value),
+            internal: T::new(initial_value),
             write_mutex: Mutex::new(mutex_value),
         }
     }
 
-    pub fn get(&self) -> T {
-        self.internal.get()
+    pub fn get(&self) -> T::Underlying {
+        self.internal.load(Ordering::Relaxed)
     }
 
-    pub async fn set_value(&self, new_value: T) {
+    pub async fn set_value(&self, new_value: T::Underlying) {
         // acquire lock
         let guard = self.write_mutex.lock().await;
 
         // update value
-        self.internal.set(new_value);
+        self.internal.store(new_value, Ordering::Relaxed);
 
         // explicitly drop guard so that it is in scope while setting cell
         drop(guard);
@@ -73,7 +67,7 @@ where
             Some(MutexGuardRefWrapper {
                 // need to get a mutable reference to internal without making the
                 // function take a mutable reference
-                internal: unsafe { self.internal.as_ptr().as_mut().unwrap() },
+                internal: &self.internal,
                 mutex_guard: guard,
             })
         } else {
@@ -87,7 +81,7 @@ where
         MutexGuardRefWrapper {
             // need to get a mutable reference to internal without making the
             // function take a mutable reference
-            internal: unsafe { self.internal.as_ptr().as_mut().unwrap() },
+            internal: &self.internal,
             mutex_guard: guard,
         }
     }

--- a/src/daemon/util/lock.rs
+++ b/src/daemon/util/lock.rs
@@ -22,6 +22,10 @@ where
     pub fn get_mut(&mut self) -> &mut T {
         self.internal
     }
+
+    pub fn split<'b>(&'b mut self) -> (&'b mut T, &'b mut MutexGuard<'a, K>) {
+        (&mut self.internal, &mut self.mutex_guard)
+    }
 }
 
 // a version of RWLock that does not block readers from reading while a writer writes

--- a/src/daemon/util/mod.rs
+++ b/src/daemon/util/mod.rs
@@ -1,2 +1,3 @@
+pub mod atomic;
 pub mod io;
 pub mod lock;


### PR DESCRIPTION
Closes #51.

I wrote the bulk of the code when I was newer to programming and to Rust, and used unsafe unnecessarily in several places. The unsafe usage was largely well-meaning and understandable for optimization purposes, but since this tool doesn't perform substantial computations they were not necessary. As an added bonus I also rewrote the README.